### PR TITLE
Allow users to connect to spotify

### DIFF
--- a/LiveLines.Api/Spotify/ISpotifyCredentialsStore.cs
+++ b/LiveLines.Api/Spotify/ISpotifyCredentialsStore.cs
@@ -5,6 +5,6 @@ namespace LiveLines.Api.Spotify;
 
 public interface ISpotifyCredentialsStore
 {
-    public Task<SpotifyCredentials> GetCredentialsForUser(LoggedInUser user);
+    public Task<SpotifyCredentials?> GetCredentialsForUser(LoggedInUser user);
     public Task UpsertCredentialsForUser(LoggedInUser user, SpotifyCredentials credentials);
 }

--- a/LiveLines.Api/Spotify/ISpotifyCredentialsStore.cs
+++ b/LiveLines.Api/Spotify/ISpotifyCredentialsStore.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using LiveLines.Api.Users;
+
+namespace LiveLines.Api.Spotify;
+
+public interface ISpotifyCredentialsStore
+{
+    public Task<SpotifyCredentials> GetCredentialsForUser(LoggedInUser user);
+    public Task UpsertCredentialsForUser(LoggedInUser user, SpotifyCredentials credentials);
+}

--- a/LiveLines.Api/Spotify/ISpotifyService.cs
+++ b/LiveLines.Api/Spotify/ISpotifyService.cs
@@ -5,7 +5,7 @@ namespace LiveLines.Api.Spotify;
 
 public interface ISpotifyService
 {
-    public Task<SpotifyCredentials> GetSpotifyCredentials(LoggedInUser user, string clientId, string clientSecret);
+    public Task<SpotifyCredentials> GetSpotifyCredentials(LoggedInUser user);
 
-    public Task UpsertSpotifyCredentials(LoggedInUser user, string code, string redirectUri, string clientId, string clientSecret);
+    public Task UpsertSpotifyCredentials(LoggedInUser user, string code, string redirectUrl);
 }

--- a/LiveLines.Api/Spotify/ISpotifyService.cs
+++ b/LiveLines.Api/Spotify/ISpotifyService.cs
@@ -5,5 +5,7 @@ namespace LiveLines.Api.Spotify;
 
 public interface ISpotifyService
 {
-    public Task UpsertSpotifyCredentials(LoggedInUser user, SpotifyCredentials credentials);
+    public Task<SpotifyCredentials> GetSpotifyCredentials(LoggedInUser user, string clientId, string clientSecret);
+
+    public Task UpsertSpotifyCredentials(LoggedInUser user, string code, string redirectUri, string clientId, string clientSecret);
 }

--- a/LiveLines.Api/Spotify/ISpotifyService.cs
+++ b/LiveLines.Api/Spotify/ISpotifyService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+using LiveLines.Api.Users;
+
+namespace LiveLines.Api.Spotify;
+
+public interface ISpotifyService
+{
+    public Task UpsertSpotifyCredentials(LoggedInUser user, SpotifyCredentials credentials);
+}

--- a/LiveLines.Api/Spotify/ISpotifyService.cs
+++ b/LiveLines.Api/Spotify/ISpotifyService.cs
@@ -5,7 +5,7 @@ namespace LiveLines.Api.Spotify;
 
 public interface ISpotifyService
 {
-    public Task<SpotifyCredentials> GetSpotifyCredentials(LoggedInUser user);
+    public Task<SpotifyCredentials?> GetSpotifyCredentials(LoggedInUser user);
 
     public Task UpsertSpotifyCredentials(LoggedInUser user, string code, string redirectUrl);
 }

--- a/LiveLines.Api/Spotify/SpotifyCredentials.cs
+++ b/LiveLines.Api/Spotify/SpotifyCredentials.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace LiveLines.Api.Spotify;
+
+public record SpotifyCredentials(
+    string AccessToken,
+    string TokenType,
+    string Scope,
+    DateTime ExpiresAt,
+    string RefreshToken);

--- a/LiveLines.Spotify/LiveLines.Spotify.csproj
+++ b/LiveLines.Spotify/LiveLines.Spotify.csproj
@@ -7,4 +7,9 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\LiveLines.Api\LiveLines.Api.csproj" />
+      <ProjectReference Include="..\LiveLines.Extensions\LiveLines.Extensions.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/LiveLines.Spotify/LiveLines.Spotify.csproj
+++ b/LiveLines.Spotify/LiveLines.Spotify.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <OutputType>Library</OutputType>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/LiveLines.Spotify/SpotifyController.cs
+++ b/LiveLines.Spotify/SpotifyController.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography;
+﻿using System.Net.Http.Headers;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
@@ -8,22 +9,17 @@ namespace LiveLines.Spotify;
 [ApiController, Route("api")]
 public class SpotifyController : ControllerBase
 {
+    private static readonly HttpClient HttpClient;
 
-    private string GenerateRandomString(int length)
+    static SpotifyController()
     {
-        var bitCount = length * 6;
-        var byteCount = (bitCount + 7) / 8; // rounded up
-        var bytes = new byte[byteCount];
-        RandomNumberGenerator.Create().GetBytes(bytes);
-        return Convert.ToBase64String(bytes);
+        HttpClient = new HttpClient();
     }
+    private const string RedirectUri = "https://localhost:44492/api/spotify/callback";
     
     [Authorize, Route("spotify/login")]
     public IActionResult Login()
     {
-        var csrfToken = GenerateRandomString(16);
-        Response.Cookies.Append(StateKey, csrfToken);
-        
         const string scope = "user-read-private user-read-email";
 
         var query = new QueryBuilder
@@ -32,17 +28,50 @@ public class SpotifyController : ControllerBase
             {"client_id", ClientId},
             {"scope", scope},
             {"redirect_uri", RedirectUri},
-            {"state", csrfToken}
         };
 
         return Redirect("https://accounts.spotify.com/authorize" + query);
     }
     
-    [AllowAnonymous, Route("spotify/callback")]
-    public Task Callback()
+    [Authorize, Route("spotify/callback")]
+    public async Task<IActionResult> Callback()
     {
-        var body = Request.Body;
-        var request = Request;
-        return Task.CompletedTask;
+        if (!Request.Query.TryGetValue("code", out var code))
+        {
+            throw new ArgumentNullException($"Spotify login callback is missing the code.");
+        }
+
+        var data = new Dictionary<string, string>
+        {
+            {"code", code.First()},
+            {"grant_type", "authorization_code"},
+            {"redirect_uri", RedirectUri},
+        };
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://accounts.spotify.com/api/token");
+        request.Content = new FormUrlEncodedContent(data);
+
+        var authValue = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{ClientId}:{ClientSecret}"));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authValue);
+        
+        var response = await HttpClient.SendAsync(request);
+        var spotifyTokenInfo = await response.Content.ReadFromJsonAsync<SpotifyTokenInfo>();
+        return Redirect("https://localhost:44492/profile");
     }
+    
+    /***
+     * From the spotify docs https://developer.spotify.com/documentation/general/guides/authorization/code-flow/
+     * 
+     * access_token 	string 	An Access Token that can be provided in subsequent calls, for example to Spotify Web API services.
+     * token_type 	string 	How the Access Token may be used: always “Bearer”.
+     * scope 	string 	A space-separated list of scopes which have been granted for this access_token
+     * expires_in 	int 	The time period (in seconds) for which the Access Token is valid.
+     * refresh_token 	string 	A token that can be sent to the Spotify Accounts service in place of an authorization code. (When the access code expires, send a POST request to the Accounts service /api/token endpoint, but use this code in place of an authorization code. A new Access Token will be returned. A new refresh token might be returned too.)
+     */
+    private record SpotifyTokenInfo(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("token_type")] string TokenType,
+        [property: JsonPropertyName("scope")] string Scope,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn,
+        [property: JsonPropertyName("refresh_token")] string RefreshToken);
 }

--- a/LiveLines.Spotify/SpotifyController.cs
+++ b/LiveLines.Spotify/SpotifyController.cs
@@ -45,42 +45,13 @@ public class SpotifyController : ControllerBase
             throw new ArgumentNullException($"Spotify login callback is missing the code.");
         }
 
-        var data = new Dictionary<string, string>
-        {
-            {"code", code.First()},
-            {"grant_type", "authorization_code"},
-            {"redirect_uri", RedirectUri},
-        };
-
-        var request = new HttpRequestMessage(HttpMethod.Post, "https://accounts.spotify.com/api/token");
-        request.Content = new FormUrlEncodedContent(data);
-
-        var authValue = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{ClientId}:{ClientSecret}"));
-        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authValue);
-        
-        var response = await HttpClient.SendAsync(request);
-        var spotifyTokenInfo = await response.Content.ReadFromJsonAsync<SpotifyCredentialsResponse>();
-
-        if (spotifyTokenInfo == null)
-        {
-            throw new ArgumentNullException($"Spotify token info not deserialised correctly from Spotify response");
-        }
-
-        var (accessToken, tokenType, scope, expiresIn, refreshToken) = spotifyTokenInfo;
-
-        // give 5 minutes of leeway
-        var expiresAt = DateTime.UtcNow.AddSeconds(expiresIn - 60 * 5);
-        var spotifyCredentials = new SpotifyCredentials(accessToken, tokenType, scope, expiresAt, refreshToken);
-        await _spotifyService.UpsertSpotifyCredentials(User.GetLoggedInUser(), spotifyCredentials);
+        await _spotifyService.UpsertSpotifyCredentials(
+            user: User.GetLoggedInUser(),
+            code: code.First(),
+            redirectUri: RedirectUri,
+            clientId: ClientId,
+            clientSecret: ClientSecret);
         
         return Redirect("https://localhost:44492/profile");
     }
-    
-    // From the spotify docs https://developer.spotify.com/documentation/general/guides/authorization/code-flow/
-    private record SpotifyCredentialsResponse(
-        [property: JsonPropertyName("access_token")] string AccessToken,
-        [property: JsonPropertyName("token_type")] string TokenType,
-        [property: JsonPropertyName("scope")] string Scope,
-        [property: JsonPropertyName("expires_in")] int ExpiresIn,
-        [property: JsonPropertyName("refresh_token")] string RefreshToken);
 }

--- a/LiveLines.Spotify/SpotifyController.cs
+++ b/LiveLines.Spotify/SpotifyController.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using System.Security.Cryptography;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LiveLines.Spotify;
@@ -6,9 +8,41 @@ namespace LiveLines.Spotify;
 [ApiController, Route("api")]
 public class SpotifyController : ControllerBase
 {
-    [AllowAnonymous]
+
+    private string GenerateRandomString(int length)
+    {
+        var bitCount = length * 6;
+        var byteCount = (bitCount + 7) / 8; // rounded up
+        var bytes = new byte[byteCount];
+        RandomNumberGenerator.Create().GetBytes(bytes);
+        return Convert.ToBase64String(bytes);
+    }
+    
+    [Authorize, Route("spotify/login")]
+    public IActionResult Login()
+    {
+        var csrfToken = GenerateRandomString(16);
+        Response.Cookies.Append(StateKey, csrfToken);
+        
+        const string scope = "user-read-private user-read-email";
+
+        var query = new QueryBuilder
+        {
+            {"response_type", "code"},
+            {"client_id", ClientId},
+            {"scope", scope},
+            {"redirect_uri", RedirectUri},
+            {"state", csrfToken}
+        };
+
+        return Redirect("https://accounts.spotify.com/authorize" + query);
+    }
+    
+    [AllowAnonymous, Route("spotify/callback")]
     public Task Callback()
     {
+        var body = Request.Body;
+        var request = Request;
         return Task.CompletedTask;
     }
 }

--- a/LiveLines.Spotify/SpotifyController.cs
+++ b/LiveLines.Spotify/SpotifyController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace LiveLines.Spotify;
 
+[Authorize]
 [ApiController, Route("api")]
 public class SpotifyController : ControllerBase
 {
@@ -24,7 +25,7 @@ public class SpotifyController : ControllerBase
         _profileCallbackUrl = hostName + "/profile";
     }
 
-    [Authorize, Route("spotify/login")]
+    [Route("spotify/login")]
     public IActionResult Login()
     {
         const string scope = "user-read-private user-read-email";
@@ -40,7 +41,7 @@ public class SpotifyController : ControllerBase
         return Redirect("https://accounts.spotify.com/authorize" + query);
     }
     
-    [Authorize, Route("spotify/callback")]
+    [Route("spotify/callback")]
     public async Task<IActionResult> Callback()
     {
         if (!Request.Query.TryGetValue("code", out var code))
@@ -52,4 +53,5 @@ public class SpotifyController : ControllerBase
         
         return Redirect(_profileCallbackUrl);
     }
+
 }

--- a/LiveLines.Spotify/SpotifyController.cs
+++ b/LiveLines.Spotify/SpotifyController.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LiveLines.Spotify;
+
+[ApiController, Route("api")]
+public class SpotifyController : ControllerBase
+{
+    [AllowAnonymous]
+    public Task Callback()
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/LiveLines.Spotify/SpotifyController.cs
+++ b/LiveLines.Spotify/SpotifyController.cs
@@ -1,5 +1,7 @@
 ﻿using System.Net.Http.Headers;
 using System.Text.Json.Serialization;
+using Extensions;
+using LiveLines.Api.Spotify;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
@@ -9,11 +11,13 @@ namespace LiveLines.Spotify;
 [ApiController, Route("api")]
 public class SpotifyController : ControllerBase
 {
-    private static readonly HttpClient HttpClient;
+    private static readonly HttpClient HttpClient = new();
 
-    static SpotifyController()
+    private readonly ISpotifyService _spotifyService;
+
+    public SpotifyController(ISpotifyService spotifyService)
     {
-        HttpClient = new HttpClient();
+        _spotifyService = spotifyService;
     }
     private const string RedirectUri = "https://localhost:44492/api/spotify/callback";
     
@@ -55,20 +59,25 @@ public class SpotifyController : ControllerBase
         request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authValue);
         
         var response = await HttpClient.SendAsync(request);
-        var spotifyTokenInfo = await response.Content.ReadFromJsonAsync<SpotifyTokenInfo>();
+        var spotifyTokenInfo = await response.Content.ReadFromJsonAsync<SpotifyCredentialsResponse>();
+
+        if (spotifyTokenInfo == null)
+        {
+            throw new ArgumentNullException($"Spotify token info not deserialised correctly from Spotify response");
+        }
+
+        var (accessToken, tokenType, scope, expiresIn, refreshToken) = spotifyTokenInfo;
+
+        // give 5 minutes of leeway
+        var expiresAt = DateTime.UtcNow.AddSeconds(expiresIn - 60 * 5);
+        var spotifyCredentials = new SpotifyCredentials(accessToken, tokenType, scope, expiresAt, refreshToken);
+        await _spotifyService.UpsertSpotifyCredentials(User.GetLoggedInUser(), spotifyCredentials);
+        
         return Redirect("https://localhost:44492/profile");
     }
     
-    /***
-     * From the spotify docs https://developer.spotify.com/documentation/general/guides/authorization/code-flow/
-     * 
-     * access_token 	string 	An Access Token that can be provided in subsequent calls, for example to Spotify Web API services.
-     * token_type 	string 	How the Access Token may be used: always “Bearer”.
-     * scope 	string 	A space-separated list of scopes which have been granted for this access_token
-     * expires_in 	int 	The time period (in seconds) for which the Access Token is valid.
-     * refresh_token 	string 	A token that can be sent to the Spotify Accounts service in place of an authorization code. (When the access code expires, send a POST request to the Accounts service /api/token endpoint, but use this code in place of an authorization code. A new Access Token will be returned. A new refresh token might be returned too.)
-     */
-    private record SpotifyTokenInfo(
+    // From the spotify docs https://developer.spotify.com/documentation/general/guides/authorization/code-flow/
+    private record SpotifyCredentialsResponse(
         [property: JsonPropertyName("access_token")] string AccessToken,
         [property: JsonPropertyName("token_type")] string TokenType,
         [property: JsonPropertyName("scope")] string Scope,

--- a/LiveLines.Spotify/SpotifyCredentialsStore.cs
+++ b/LiveLines.Spotify/SpotifyCredentialsStore.cs
@@ -1,0 +1,17 @@
+﻿using LiveLines.Api.Spotify;
+using LiveLines.Api.Users;
+
+namespace LiveLines.Spotify;
+
+public class SpotifyCredentialsStore : ISpotifyCredentialsStore
+{
+    public Task<SpotifyCredentials> GetCredentialsForUser(LoggedInUser user)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task UpsertCredentialsForUser(LoggedInUser user, SpotifyCredentials credentials)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/LiveLines.Spotify/SpotifyCredentialsStore.cs
+++ b/LiveLines.Spotify/SpotifyCredentialsStore.cs
@@ -1,13 +1,51 @@
-﻿using LiveLines.Api.Spotify;
+﻿using Extensions;
+using LiveLines.Api.Database;
+using LiveLines.Api.Lines;
+using LiveLines.Api.Spotify;
 using LiveLines.Api.Users;
 
 namespace LiveLines.Spotify;
 
 public class SpotifyCredentialsStore : ISpotifyCredentialsStore
 {
-    public Task<SpotifyCredentials> GetCredentialsForUser(LoggedInUser user)
+    private readonly IDatabaseCommandExecutor _dbExecutor;
+
+    public SpotifyCredentialsStore(IDatabaseCommandExecutor dbExecutor)
     {
-        throw new NotImplementedException();
+        _dbExecutor = dbExecutor;
+    }
+    
+    public async Task<SpotifyCredentials?> GetCredentialsForUser(LoggedInUser user)
+    {
+        return await _dbExecutor.ExecuteCommand(async cmd =>
+        {
+            cmd.AddParam("@userId", user.InternalId);
+
+            cmd.CommandText = @"
+                    SELECT user_id, access_token, refresh_token, token_type, ""scope"", expires_at
+                    FROM spotify_credentials 
+                    WHERE user_id = @userId;";
+
+            var reader = await cmd.ExecuteReaderAsync();
+
+            if (!await reader.ReadAsync())
+            {
+                return null;
+            }
+
+            var accessToken = reader.Get<string>("access_token");
+            var refreshToken = reader.Get<string>("refresh_token");
+            var tokenType = reader.Get<string>("token_type");
+            var scope = reader.Get<string>("scope");
+            var expiresAt = reader.Get<DateTime>("expires_at");
+
+            return new SpotifyCredentials(
+                AccessToken: accessToken,
+                TokenType: tokenType,
+                Scope: scope,
+                ExpiresAt: expiresAt,
+                RefreshToken: refreshToken);
+        });
     }
 
     public Task UpsertCredentialsForUser(LoggedInUser user, SpotifyCredentials credentials)

--- a/LiveLines.Spotify/SpotifyService.cs
+++ b/LiveLines.Spotify/SpotifyService.cs
@@ -20,9 +20,15 @@ public class SpotifyService : ISpotifyService
         _spotifyCredentialsStore = spotifyCredentialsStore;
     }
 
-    public async Task<SpotifyCredentials> GetSpotifyCredentials(LoggedInUser user)
+    public async Task<SpotifyCredentials?> GetSpotifyCredentials(LoggedInUser user)
     {
         var spotifyCredentials = await _spotifyCredentialsStore.GetCredentialsForUser(user);
+
+        if (spotifyCredentials == null)
+        {
+            return null;
+        }
+        
         if (spotifyCredentials.ExpiresAt < DateTime.UtcNow)
         {
             return await RefreshAccessToken(spotifyCredentials.RefreshToken);

--- a/LiveLines.Spotify/SpotifyService.cs
+++ b/LiveLines.Spotify/SpotifyService.cs
@@ -1,0 +1,19 @@
+﻿using LiveLines.Api.Spotify;
+using LiveLines.Api.Users;
+
+namespace LiveLines.Spotify;
+
+public class SpotifyService : ISpotifyService
+{
+    private readonly ISpotifyCredentialsStore _spotifyCredentialsStore;
+
+    public SpotifyService(ISpotifyCredentialsStore spotifyCredentialsStore)
+    {
+        _spotifyCredentialsStore = spotifyCredentialsStore;
+    }
+
+    public Task UpsertSpotifyCredentials(LoggedInUser user, SpotifyCredentials credentials)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/LiveLines.Spotify/SpotifyService.cs
+++ b/LiveLines.Spotify/SpotifyService.cs
@@ -1,10 +1,14 @@
-﻿using LiveLines.Api.Spotify;
+﻿using System.Net.Http.Headers;
+using System.Text.Json.Serialization;
+using LiveLines.Api.Spotify;
 using LiveLines.Api.Users;
 
 namespace LiveLines.Spotify;
 
 public class SpotifyService : ISpotifyService
 {
+    private static readonly HttpClient HttpClient = new ();
+    
     private readonly ISpotifyCredentialsStore _spotifyCredentialsStore;
 
     public SpotifyService(ISpotifyCredentialsStore spotifyCredentialsStore)
@@ -12,8 +16,78 @@ public class SpotifyService : ISpotifyService
         _spotifyCredentialsStore = spotifyCredentialsStore;
     }
 
-    public Task UpsertSpotifyCredentials(LoggedInUser user, SpotifyCredentials credentials)
+    public async Task<SpotifyCredentials> GetSpotifyCredentials(LoggedInUser user, string clientId, string clientSecret)
     {
-        throw new NotImplementedException();
+        var spotifyCredentials = await _spotifyCredentialsStore.GetCredentialsForUser(user);
+        if (spotifyCredentials.ExpiresAt < DateTime.UtcNow)
+        {
+            return await RefreshAccessToken(spotifyCredentials.RefreshToken, clientId, clientSecret);
+        }
+
+        return spotifyCredentials;
     }
+
+    private async Task<SpotifyCredentials> RefreshAccessToken(string refreshTokenRequest, string clientId, string clientSecret)
+    {
+        var data = new Dictionary<string, string>
+        {
+            {"refresh_token", refreshTokenRequest},
+            {"grant_type", "refresh_token"},
+        };
+
+        var credentialsResponse = await GetSpotifyCredentialsFromOptions(clientId, clientSecret, data);
+
+        return GetCredentialsFromResponse(credentialsResponse);
+    }
+
+    public async Task UpsertSpotifyCredentials(LoggedInUser user, string code, string redirectUri, string clientId, string clientSecret)
+    {
+        var data = new Dictionary<string, string>
+        {
+            {"code", code},
+            {"grant_type", "authorization_code"},
+            {"redirect_uri", redirectUri},
+        };
+
+        var credentialsResponse = await GetSpotifyCredentialsFromOptions(clientId, clientSecret, data);
+        var spotifyCredentials = GetCredentialsFromResponse(credentialsResponse);
+
+        await _spotifyCredentialsStore.UpsertCredentialsForUser(user, spotifyCredentials);
+    }
+    
+    private SpotifyCredentials GetCredentialsFromResponse(SpotifyCredentialsResponse credentialsResponse)
+    {
+        var (accessToken, tokenType, scope, expiresIn, refreshToken) = credentialsResponse;
+        
+        // give 5 minutes of leeway
+        var expiresAt = DateTime.UtcNow.AddSeconds(expiresIn - 60 * 5);
+        return new SpotifyCredentials(accessToken, tokenType, scope, expiresAt, refreshToken);
+    }
+
+    private static async Task<SpotifyCredentialsResponse> GetSpotifyCredentialsFromOptions(string clientId, string clientSecret, Dictionary<string, string> data)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://accounts.spotify.com/api/token");
+        request.Content = new FormUrlEncodedContent(data);
+
+        var authValue = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{clientId}:{clientSecret}"));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authValue);
+
+        var response = await HttpClient.SendAsync(request);
+        var spotifyTokenInfo = await response.Content.ReadFromJsonAsync<SpotifyCredentialsResponse>();
+
+        if (spotifyTokenInfo == null)
+        {
+            throw new ArgumentNullException($"Spotify token info not deserialised correctly from Spotify response");
+        }
+
+        return spotifyTokenInfo;
+    }
+
+    // From the spotify docs https://developer.spotify.com/documentation/general/guides/authorization/code-flow/
+    private record SpotifyCredentialsResponse(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("token_type")] string TokenType,
+        [property: JsonPropertyName("scope")] string Scope,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn,
+        [property: JsonPropertyName("refresh_token")] string RefreshToken);
 }

--- a/LiveLines.Users/UserController.cs
+++ b/LiveLines.Users/UserController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Extensions;
+using LiveLines.Api.Spotify;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -9,12 +10,23 @@ namespace LiveLines.Users;
 [ApiController, Route("api")]
 public class UserController : ControllerBase
 {
-    public record ProfileResponse(string Username);
+    private readonly ISpotifyService _spotifyService;
+
+    public UserController(ISpotifyService spotifyService)
+    {
+        _spotifyService = spotifyService;
+    }
+
+    public record ProfileResponse(string Username, bool SpotifyLoggedIn);
     
     [HttpGet, Route("user/profile")]
-    public Task<ProfileResponse> GetProfile()
+    public async Task<ProfileResponse> GetProfile()
     {
         var user = User.GetLoggedInUser();
-        return Task.FromResult(new ProfileResponse(user.Username));
+        
+        var spotifyCredentials = await _spotifyService.GetSpotifyCredentials(User.GetLoggedInUser());
+        var hasSpotifyCreds = spotifyCredentials != null;
+        
+        return new ProfileResponse(user.Username, hasSpotifyCreds);
     }
 }

--- a/LiveLines.sln
+++ b/LiveLines.sln
@@ -20,6 +20,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiveLines.Songs", "LiveLine
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiveLines.Streaks", "LiveLines.Streaks\LiveLines.Streaks.csproj", "{1F603826-F85C-48E6-9FC8-B30885090D68}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiveLines.Spotify", "LiveLines.Spotify\LiveLines.Spotify.csproj", "{B78595EC-840A-4CD4-8AEE-684F5AA9F0AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,5 +68,9 @@ Global
 		{1F603826-F85C-48E6-9FC8-B30885090D68}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1F603826-F85C-48E6-9FC8-B30885090D68}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1F603826-F85C-48E6-9FC8-B30885090D68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B78595EC-840A-4CD4-8AEE-684F5AA9F0AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B78595EC-840A-4CD4-8AEE-684F5AA9F0AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B78595EC-840A-4CD4-8AEE-684F5AA9F0AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B78595EC-840A-4CD4-8AEE-684F5AA9F0AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/LiveLines/ClientApp/src/pages/Profile.js
+++ b/LiveLines/ClientApp/src/pages/Profile.js
@@ -9,6 +9,8 @@ export function Profile() {
   const { user } = useContext(UserContext);
 
   const [userInfo, setUserInfo] = useState({});
+  
+  const [spotifyLoggedIn, setSpotifyLoggedIn] = useState(false);
 
   const loginSpotify = 'api/spotify/login';
   const logout = 'api/logout';
@@ -17,6 +19,7 @@ export function Profile() {
     const resp = await getData("api/user/profile");
     const profileResp = await resp.json();
     setUserInfo({ username: profileResp.username });
+    setSpotifyLoggedIn(profileResp.spotifyLoggedIn);
   }
   
   useEffect(() => {
@@ -25,11 +28,17 @@ export function Profile() {
     }
   }, [user.authenticated]);
 
+  const spotifyLoginOrStatus = () => {
+    return spotifyLoggedIn
+      ? <span className='pb-3'>Logged into Spotify<BsSpotify className="ml-2 mb-1 inline-block"/></span>
+      : <a className='pb-3' href={loginSpotify}>Login to Spotify<BsSpotify className="ml-2 mb-1 inline-block"/></a>
+  }
+
   return (
     <div className="h-max mx-auto border border-slate-300 bg-white w-max mt-10">
       <div className='flex flex-col items-center px-20 py-10'>
         <div className='text-3xl pb-5'>{userInfo.username}</div>
-        <a className='pb-3' href={loginSpotify}>Login to Spotify<BsSpotify className="ml-2 mb-1 inline-block"/></a>
+        {spotifyLoginOrStatus()}
         <div>
           <span>Logout</span>
           <a href={logout}><FiLogOut className="ml-2 mb-1 inline-block"/></a>

--- a/LiveLines/ClientApp/src/pages/Profile.js
+++ b/LiveLines/ClientApp/src/pages/Profile.js
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { FiLogOut } from 'react-icons/fi';
 import { getData, postData } from "../Api";
 import { UserContext } from '../auth/UserContext';
+import { BsSpotify } from 'react-icons/bs';
 
 export function Profile() {
   
@@ -9,6 +10,7 @@ export function Profile() {
 
   const [userInfo, setUserInfo] = useState({});
 
+  const loginSpotify = 'api/spotify/login';
   const logout = 'api/logout';
   
   const getUserProfile = async () => {
@@ -27,6 +29,7 @@ export function Profile() {
     <div className="h-max mx-auto border border-slate-300 bg-white w-max mt-10">
       <div className='flex flex-col items-center px-20 py-10'>
         <div className='text-3xl pb-5'>{userInfo.username}</div>
+        <a className='pb-3' href={loginSpotify}>Login to Spotify<BsSpotify className="ml-2 mb-1 inline-block"/></a>
         <div>
           <span>Logout</span>
           <a href={logout}><FiLogOut className="ml-2 mb-1 inline-block"/></a>

--- a/LiveLines/LiveLines.csproj
+++ b/LiveLines/LiveLines.csproj
@@ -27,6 +27,7 @@
         <ProjectReference Include="..\LiveLines.Songs\LiveLines.Songs.csproj" />
         <ProjectReference Include="..\LiveLines.Streaks\LiveLines.Streaks.csproj" />
         <ProjectReference Include="..\LiveLines.Users\LiveLines.Users.csproj" />
+        <ProjectReference Include="..\LiveLines.Spotify\LiveLines.Spotify.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/LiveLines/Properties/launchSettings.json
+++ b/LiveLines/Properties/launchSettings.json
@@ -5,6 +5,7 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7280;http://localhost:5280",
       "environmentVariables": {
+        "HOST_NAME": "https://localhost:44492",
         "ASPNETCORE_ENVIRONMENT": "Development",
         "GITHUB_CLIENT_ID": "replace_me",
         "GITHUB_CLIENT_SECRET": "replace_me",
@@ -14,7 +15,9 @@
         "DB_PORT": "5432",
         "DB_USER_NAME": "dev",
         "DB_PASSWORD": "test",
-        "DB_MAX_POOL_SIZE": "5"
+        "DB_MAX_POOL_SIZE": "5",
+        "SPOTIFY_CLIENT_ID": "replace_me",
+        "SPOTIFY_CLIENT_SECRET": "replace_me"
       }
     }
   }

--- a/LiveLines/ServiceModuleExtension.cs
+++ b/LiveLines/ServiceModuleExtension.cs
@@ -1,11 +1,13 @@
 ﻿using LiveLines.Api.Database;
 using LiveLines.Api.Lines;
 using LiveLines.Api.Songs;
+using LiveLines.Api.Spotify;
 using LiveLines.Api.Streaks;
 using LiveLines.Api.Users;
 using LiveLines.Database;
 using LiveLines.Lines;
 using LiveLines.Songs;
+using LiveLines.Spotify;
 using LiveLines.Streaks;
 using LiveLines.Users;
 
@@ -26,6 +28,8 @@ public static class ServiceModuleExtension
             .AddSingleton<ISongStore, SongStore>()
             .AddSingleton<ISongService, SongService>()
             .AddSingleton<IStreakService, StreakService>()
+            .AddSingleton<ISpotifyService, SpotifyService>()
+            .AddSingleton<ISpotifyCredentialsStore, SpotifyCredentialsStore>()
             ;
     }
 }

--- a/db.sql
+++ b/db.sql
@@ -57,5 +57,20 @@ BEGIN;
     ALTER TABLE lines
     ALTER COLUMN date_for SET NOT NULL;
 COMMIT;
--- end 
+-- end
 
+-- v3: create spotify table for access tokens
+BEGIN;
+    CREATE TABLE spotify_credentials
+    (
+        user_id UUID PRIMARY KEY REFERENCES users,
+        access_token TEXT NOT NULL,
+        refresh_token TEXT NOT NULL,
+        token_type TEXT NOT NULL,
+        scope TEXT NOT NULL,
+        expires_at TIMESTAMP WITH TIME ZONE NOT NULL
+    );
+
+    GRANT UPDATE, INSERT, SELECT ON TABLE spotify_credentials TO dev;
+COMMIT;
+--end


### PR DESCRIPTION
This will later be used to allow people to attach music they've listened to recently to a line.

Based off the spotify oauth flow docs, specifically the `code flow`: https://developer.spotify.com/documentation/general/guides/authorization/code-flow/

Before merging I need to:
✔️ Create the production env vars for the spotify oauth flow and host name
⏳ Run db changes