### PR TITLE
Fix streaks with posting yesterday

### DIFF
--- a/LiveLines.Api/Streaks/IStreakService.cs
+++ b/LiveLines.Api/Streaks/IStreakService.cs
@@ -5,7 +5,7 @@ namespace LiveLines.Api.Streaks;
 
 public interface IStreakService
 {
-    Task<int> IncrementStreak(LoggedInUser user);
+    Task<int> UpdateStreakForNewLine(LoggedInUser user, bool forYesterday);
 
-    Task<int> GetStreak(LoggedInUser user);
+    Task<int> GetOrCreateStreak(LoggedInUser user);
 }

--- a/LiveLines.Lines/LinesController.cs
+++ b/LiveLines.Lines/LinesController.cs
@@ -47,7 +47,7 @@ public class LinesController : ControllerBase
         var lineToCreate = new LineToCreate(lineRequest.Message, lineRequest.SongId, lineRequest.ForYesterday);
         var line = await _linesService.CreateLine(user, lineToCreate);
 
-        await _streakService.IncrementStreak(user);
+        await _streakService.UpdateStreakForNewLine(user, lineRequest.ForYesterday);
 
         return new LineResponse(line.Id, line.Message, line.SpotifyId, line.DateFor);
     }

--- a/LiveLines.Streaks/StreakController.cs
+++ b/LiveLines.Streaks/StreakController.cs
@@ -21,7 +21,7 @@ public class StreakController : ControllerBase
     [HttpGet, Route("streak")]
     public async Task<StreakResponse> GetStreak()
     {
-        var streak = await _streakService.GetStreak(User.GetLoggedInUser());
+        var streak = await _streakService.GetOrCreateStreak(User.GetLoggedInUser());
         return new StreakResponse(streak);
     }
 }

--- a/LiveLines.Streaks/StreakService.cs
+++ b/LiveLines.Streaks/StreakService.cs
@@ -41,7 +41,6 @@ public class StreakService : IStreakService
             GetStreakCacheKey(user),
             async cacheEntry =>
             {
-                
                 cacheEntry.AbsoluteExpiration = GenerateStreakExpiry();
                 return await GetStreakCount(user);
             });

--- a/LiveLines/ClientApp/src/pages/Home.js
+++ b/LiveLines/ClientApp/src/pages/Home.js
@@ -69,7 +69,13 @@ export function Home() {
     });
     
     // update the streak in the nav bar
-    setStreak(user.streak + 1);
+    if (postYesterdayInput) {
+      const resp = await getData("api/streak");
+      const streakResp = await resp.json();
+      setStreak(streakResp.streakCount);
+    } else {
+      setStreak(user.streak + 1);
+    }
     
     const newLine = await newLineResp.json();
     const parsedNewLine = parseLine(newLine);


### PR DESCRIPTION
There were a couple of bugs to do with the streaks, this fixes them.

The first is that posting yesterday didn't continue the streak from the days before, so now we rerun the calculation if it's for yesterday.

Another bug was that posting a line after the entry had expired in the cache would both fetch the current streak (after the line had been created) and add one, so it would've showed up at 2, instead of 1.

